### PR TITLE
improve withdraw time remaining tooltip wording in low time scenarios

### DIFF
--- a/liquidity/ui/src/components/Assets/AssetTable/AssetsRow.tsx
+++ b/liquidity/ui/src/components/Assets/AssetTable/AssetsRow.tsx
@@ -34,9 +34,31 @@ export const AssetsRow = ({
   const { isOpen, onOpen, onClose } = useDisclosure();
   const canWithdraw = unlockDate.getTime() < new Date().getTime();
 
-  const hoursToWithdraw = canWithdraw
-    ? ''
-    : new Date(unlockDate.getDate() - new Date().getTime()).getHours();
+  const pluralize = (value: number, word: string) => {
+    return value === 1 ? word : `${word}s`;
+  };
+
+  const getTimeToWithdraw = () => {
+    if (canWithdraw) {
+      return '';
+    }
+
+    const timeDiff = new Date(unlockDate.getDate() - new Date().getTime());
+
+    const hoursToWithdraw = timeDiff.getHours();
+    if (hoursToWithdraw > 0) {
+      return `${hoursToWithdraw} ${pluralize(hoursToWithdraw, 'hour')}`;
+    }
+    
+    const minutesToWithdraw = timeDiff.getMinutes();
+    if (minutesToWithdraw > 0) {
+      return `${minutesToWithdraw} ${pluralize(minutesToWithdraw, 'minute')}`;
+    }
+
+    const secondsToWithdraw = timeDiff.getSeconds();
+    return `${secondsToWithdraw} ${pluralize(secondsToWithdraw, 'second')}`; 
+  };
+  
 
   return (
     <Tr borderBottomWidth={final ? 'none' : '1px'}>
@@ -125,7 +147,7 @@ export const AssetsRow = ({
               label={
                 !canWithdraw &&
                 accountBalance.gt(0) &&
-                `Withdrawal available in ${hoursToWithdraw} hours`
+                `Withdrawal available in ${getTimeToWithdraw()}`
               }
             >
               <Button


### PR DESCRIPTION
Improves scenarios where the user has less than one hour remaining time to withdraw. Previously the UI would show "Withdrawal available in 0 hours" which is not informative as it covers everything from 1 second to 59m 59s.

UI tooltip will now show minute and second increments for the time remaining, with proper pluralization on 1 hour / 1 minute / 1 second times.

<img width="465" alt="image" src="https://github.com/Synthetixio/v3ui/assets/137969418/4159d90d-2b54-43b4-aa73-4d151fb69403">
