### PR TITLE
Fix rewards display for base andromeda

### DIFF
--- a/liquidity/ui/src/components/Rewards/Rewards.tsx
+++ b/liquidity/ui/src/components/Rewards/Rewards.tsx
@@ -29,7 +29,7 @@ export const Rewards = ({
   readOnly = false,
   ...props
 }: RewardsDistributorsInterface) => {
-  const empty = rewards && rewards.length === 0;
+  const hasRewards = rewards && rewards.length > 0;
 
   return (
     <BorderBox bg="navy.700" py={4} px={4} flexDir="column" {...props}>
@@ -37,7 +37,7 @@ export const Rewards = ({
         REWARDS
       </Text>
       <TableContainer width="100%" mb="8px">
-        {empty ? (
+        {!hasRewards ? (
           <Fade in>
             <Flex mt="20px" mb="8px" justifyContent="center">
               <Text color="gray.500" fontFamily="heading" lineHeight="4" fontSize="xs">

--- a/liquidity/ui/src/pages/Manage/Manage.tsx
+++ b/liquidity/ui/src/pages/Manage/Manage.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import React, { FC } from 'react';
 import { Box, Divider, Flex, Heading, Link, Text } from '@chakra-ui/react';
 import { BorderBox } from '@snx-v3/BorderBox';
 import { useParams } from '@snx-v3/useParams';
@@ -16,6 +16,35 @@ import { LiquidityPosition, useLiquidityPosition } from '@snx-v3/useLiquidityPos
 import { isBaseAndromeda } from '@snx-v3/isBaseAndromeda';
 import { Network, useNetwork } from '@snx-v3/useBlockchain';
 
+function useNormalisedCollateralSymbol(collateralSymbol?: string) {
+  const { network } = useNetwork();
+
+  return React.useMemo(() => {
+    if (collateralSymbol !== 'USDC') {
+      return collateralSymbol;
+    }
+    if (!network?.id && network?.preset) {
+      return undefined;
+    }
+    return isBaseAndromeda(network?.id, network?.preset) && collateralSymbol === 'USDC'
+      ? 'sUSDC'
+      : collateralSymbol;
+  }, [network?.id, network?.preset, collateralSymbol]);
+}
+
+function useCollateralDisplayName(collateralSymbol?: string) {
+  const { network } = useNetwork();
+
+  return React.useMemo(() => {
+    if (!network?.id && network?.preset) {
+      return undefined;
+    }
+    return isBaseAndromeda(network?.id, network?.preset) && collateralSymbol === 'sUSDC'
+      ? 'USDC'
+      : collateralSymbol;
+  }, [network?.id, network?.preset, collateralSymbol]);
+}
+
 export const ManageUi: FC<{
   collateralType?: CollateralType;
   isLoading: boolean;
@@ -24,6 +53,7 @@ export const ManageUi: FC<{
   network?: Network | null;
   collateralSymbol?: string;
 }> = ({ isLoading, rewards, liquidityPosition, network, collateralSymbol }) => {
+  const collateralDisplayName = useCollateralDisplayName(collateralSymbol);
   return (
     <Box mb={12} mt={8}>
       <Box mb="4">
@@ -56,7 +86,7 @@ export const ManageUi: FC<{
           alignItems="center"
           data-cy="manage-position-title"
         >
-          {collateralSymbol} Liquidity Position
+          {collateralDisplayName} Liquidity Position
         </Heading>
       </Flex>
       <Text color="gray.500" fontFamily="heading" fontSize="14px" lineHeight="20px" width="80%">
@@ -102,7 +132,9 @@ export const ManageUi: FC<{
 };
 
 export const Manage = () => {
-  const { accountId, collateralSymbol, poolId } = useParams();
+  const { accountId, collateralSymbol: collateralSymbolRaw, poolId } = useParams();
+  const collateralSymbol = useNormalisedCollateralSymbol(collateralSymbolRaw);
+
   const { network } = useNetwork();
 
   const { isLoading: isCollateralLoading, data: collateralType } =


### PR DESCRIPTION
Main issue was with USDC not being a valid collateral. USDC only needs to exist as a display name and only replaces in places where we show the text, not in a global collateral list. I haven't done any refactoring and only update Manage page for now to encode/decode real CollateralType. Will do a proper refactoring later.

![image](https://github.com/Synthetixio/v3ui/assets/28145325/02c0ee0a-a7c9-47dd-8b8f-3a4758d94924)
