### PR TITLE
Remove getRewardRate usage

### DIFF
--- a/liquidity/lib/useRewards/useRewards.ts
+++ b/liquidity/lib/useRewards/useRewards.ts
@@ -15,7 +15,6 @@ const RewardsResponseSchema = z.array(
     symbol: z.string(),
     claimableAmount: z.instanceof(Wei),
     distributorAddress: z.string(),
-    rate: z.number(),
     duration: z.number(),
     lifetimeClaimed: z.number(),
     total: z.number(),
@@ -175,7 +174,7 @@ export function useRewards(
           : distributorResult;
 
         const { returnData: ercReturnData } = await Multicall3.callStatic.aggregate(
-          filteredDistributors.flatMap(({ token, distributorCollateralType, address }) => [
+          filteredDistributors.flatMap(({ token }) => [
             {
               target: token,
               callData: ifaceERC20.encodeFunctionData('name', []),
@@ -188,26 +187,13 @@ export function useRewards(
               target: token,
               callData: ifaceERC20.encodeFunctionData('decimals', []),
             },
-            {
-              target: CoreProxy.address,
-              callData: CoreProxy.interface.encodeFunctionData('getRewardRate', [
-                BigNumber.from(poolId),
-                distributorCollateralType,
-                address,
-              ]),
-            },
           ])
         );
 
         const result = filteredDistributors.map((item, i) => {
-          const [name] = ifaceERC20.decodeFunctionResult('name', ercReturnData[i * 4]);
-          const [symbol] = ifaceERC20.decodeFunctionResult('symbol', ercReturnData[i * 4 + 1]);
-          const [decimals] = ifaceERC20.decodeFunctionResult('decimals', ercReturnData[i * 4 + 2]);
-
-          const rewardRate = CoreProxy.interface.decodeFunctionResult(
-            'getRewardRate',
-            ercReturnData[i * 4 + 3]
-          );
+          const [name] = ifaceERC20.decodeFunctionResult('name', ercReturnData[i * 3]);
+          const [symbol] = ifaceERC20.decodeFunctionResult('symbol', ercReturnData[i * 3 + 1]);
+          const [decimals] = ifaceERC20.decodeFunctionResult('decimals', ercReturnData[i * 3 + 2]);
 
           const total = wei(item.total, 18, true).toNumber();
 
@@ -216,8 +202,6 @@ export function useRewards(
             name,
             symbol,
             decimals,
-            // Reward rate is the amount of rewards per second
-            rewardRate: wei(rewardRate),
             total,
           };
         });
@@ -238,14 +222,12 @@ export function useRewards(
               ...item,
               claimableAmount: wei(response),
               distributorAddress: item.address,
-              rate: item.rewardRate.toNumber(),
             });
           } catch (error) {
             balances.push({
               ...item,
               claimableAmount: wei(0),
               distributorAddress: item.address,
-              rate: item.rewardRate.toNumber(),
             });
           }
         }

--- a/liquidity/ui/src/components/Rewards/Rewards.tsx
+++ b/liquidity/ui/src/components/Rewards/Rewards.tsx
@@ -106,7 +106,6 @@ export const Rewards = ({
                     symbol={item.symbol}
                     claimableAmount={item.claimableAmount.toNumber()}
                     frequency={item.duration}
-                    projectedAmount={item.rate / item.duration || 0}
                     lifetimeClaimed={item.lifetimeClaimed}
                     hasClaimed={item.lifetimeClaimed > 0}
                     address={item.distributorAddress}

--- a/liquidity/ui/src/components/Rewards/RewardsRow.cy.tsx
+++ b/liquidity/ui/src/components/Rewards/RewardsRow.cy.tsx
@@ -17,7 +17,6 @@ describe('RewardsRow', () => {
   it('renders the component with the correct data', () => {
     const props = {
       symbol: 'ETH',
-      projectedAmount: 100,
       frequency: 3600,
       claimableAmount: 50,
       lifetimeClaimed: 25,

--- a/liquidity/ui/src/components/Rewards/RewardsRow.tsx
+++ b/liquidity/ui/src/components/Rewards/RewardsRow.tsx
@@ -13,7 +13,6 @@ import { Tooltip } from '@snx-v3/Tooltip';
 
 interface RewardsRowInterface {
   symbol: string;
-  projectedAmount: number; // The amount per frequency period
   frequency: number;
   claimableAmount: number; // The immediate amount claimable as read from the contracts
   lifetimeClaimed: number;


### PR DESCRIPTION
fixes Base Mainnet, as `getRewardRate` fails with division by zero

![image](https://github.com/Synthetixio/v3ui/assets/28145325/18152742-fda3-4b44-9b08-2a3e9644a4a0)
