### PR TITLE
Fixing typo in migration modal

### DIFF
--- a/liquidity/ui/src/components/Migration/StepSummary.tsx
+++ b/liquidity/ui/src/components/Migration/StepSummary.tsx
@@ -220,7 +220,7 @@ export const StepSummary = ({
           <AlertIcon />
           <AlertDescription fontSize="16px">
             The minimal locked amount on V3 is <Amount value={snxCollateral?.minDelegationD18} />{' '}
-            SNX. You can manually unstaked your V2 SNX on the{' '}
+            SNX. You can manually unstake your V2 SNX on the{' '}
             <Link
               textDecoration="underline"
               href="https://staking.synthetix.io/staking/burn"


### PR DESCRIPTION
Changing "manually unstaked your V2 SNX" to "manually unstake your V2 SNX"